### PR TITLE
Fixed bug in GZIPMemberWriterCommittedOutputStream that was leading to incorrect ZipNumWriterTool output

### DIFF
--- a/archive-commons/src/main/java/org/archive/format/gzip/GZIPMemberWriterCommittedOutputStream.java
+++ b/archive-commons/src/main/java/org/archive/format/gzip/GZIPMemberWriterCommittedOutputStream.java
@@ -9,19 +9,30 @@ import org.archive.util.io.CommitedOutputStream;
 public class GZIPMemberWriterCommittedOutputStream extends CommitedOutputStream {
 	private static int DEFAULT_BUFFER_RAM = 1024 * 1024;
 	private GZIPMemberWriter gzW;
+
 	public GZIPMemberWriterCommittedOutputStream(GZIPMemberWriter gzW) {
-		this(gzW,DEFAULT_BUFFER_RAM);
+		this(gzW, DEFAULT_BUFFER_RAM);
 	}
+
 	public GZIPMemberWriterCommittedOutputStream(GZIPMemberWriter gzW, int bufferRAM) {
-                super(new ByteArrayOutputStream());
+    super(new ByteArrayOutputStream());
 		this.gzW = gzW;
 	}
 
 	@Override
 	public void commit() throws IOException {
-                ByteArrayOutputStream bos = (ByteArrayOutputStream) out;
+    ByteArrayOutputStream bos = (ByteArrayOutputStream) out;
 		gzW.write(new ByteArrayInputStream(bos.toByteArray()));
+
+    // Without a reset here on the ByteArrayOutputStream, which serves
+    // as the place in memory for buffering data to be compressed into a
+    // GZip member, each GZip member ends up containing all data
+    // previously written to the stream in addition to that actually
+    // intended for the current write. Examining output from
+    // ZipNumWriterTool without the fix demonstrates this. [Youssef Eldakar]
+    bos.reset();
 	}
+
 	public long getBytesWritten() {
 		return gzW.getBytesWritten();
 	}


### PR DESCRIPTION
GZIPMemberWriterCommittedOutputStream.commit() was missing a reset on the ByteArrayOutputStream. Consequently, GZip members in output from ZipNumWriterTool with limit = 3000 were looking like this:

GZip member containing first 3000 lines of input
GZip member containing first 6000 lines of input
GZip member containing first 9000 lines of input

etc.
